### PR TITLE
Create test_timestamp_fromisoformat.py

### DIFF
--- a/pandas/tests/scalar/timestamp/test_timestamp_fromisoformat.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp_fromisoformat.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import pytest
+# to test and assert that Timestamp.fromisoformat should return a timezone aware timestamp
+
+def test_timestamp_fromisoformat_timezone_handling():
+    # Test case for ISO 8601 string with Zulu (UTC) timezone
+    timestr_utc = '2023-11-05T08:30:00Z'
+    ts_utc = pd.Timestamp.fromisoformat(timestr_utc)
+    assert ts_utc == pd.to_datetime(timestr_utc), "UTC timezone not handled correctly"
+
+    # Test case for ISO 8601 string with the offset timezone
+    timestr_offset = '2023-11-05T08:30:00+0000'
+    ts_offset = pd.Timestamp.fromisoformat(timestr_offset)
+    assert ts_offset == pd.to_datetime(timestr_offset), "Offset timezone not handled correctly"
+
+    # Test case for a roundtrip conversion
+    ts_now = pd.Timestamp.utcnow()
+    assert ts_now == pd.Timestamp.fromisoformat(ts_now.isoformat()), "Roundtrip conversion loses timezone information"


### PR DESCRIPTION
this test case is similar to the example in bug (issue#56398) to verify that Timestamp.fromisoformat method behaves as expected in different scenarios, specifically in handling timezone information.

- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
